### PR TITLE
Chap 2 - Exemple isin() et tilde, utiliser plus .loc

### DIFF
--- a/src/02-selection.ipynb
+++ b/src/02-selection.ipynb
@@ -648,7 +648,8 @@
     "* Égal, pas égal : `==`, `!=`\n",
     "* Plus grand que, plus petit que : `>`, `<`\n",
     "* Plus grand ou égal, plus petit ou égal : `>=`, `<=`\n",
-    "* Opérateurs par élément ET et OU : `&` et `|`"
+    "* Opérateurs par élément ET et OU : `&` et `|`\n",
+    "* Opérateur d'inversion : `~`"
    ]
   },
   {
@@ -663,7 +664,124 @@
     "* Equal, not equal: `==`, `!=`\n",
     "* Greater than, less than: `>`, `<`\n",
     "* Greater than or equal to, less than or equal to: `>=`, `<=`\n",
-    "* Element-wise AND and OR operators: `&` and `|`"
+    "* Element-wise AND and OR operators: `&` and `|`\n",
+    "* Invert operator: `~`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43358a98-ed2e-42ed-bcce-8054ad7bb8a0",
+   "metadata": {
+    "lang": "fr"
+   },
+   "outputs": [],
+   "source": [
+    "# Sélection de trois années\n",
+    "surveys_df[\n",
+    "    (surveys_df['year'] == 1991) |\n",
+    "    (surveys_df['year'] == 1996) |\n",
+    "    (surveys_df['year'] == 2001)\n",
+    "].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d370b9aa-4c82-4d39-955e-0c2501f18f79",
+   "metadata": {
+    "lang": "en"
+   },
+   "outputs": [],
+   "source": [
+    "# Selection of three years\n",
+    "surveys_df[\n",
+    "    (surveys_df['year'] == 1991) |\n",
+    "    (surveys_df['year'] == 1996) |\n",
+    "    (surveys_df['year'] == 2001)\n",
+    "].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7615c90f-77ae-425d-b955-6218e9956f89",
+   "metadata": {
+    "lang": "fr"
+   },
+   "outputs": [],
+   "source": [
+    "# Sélection de trois années avec isin()\n",
+    "surveys_df[\n",
+    "    surveys_df['year'].isin([1991, 1996, 2001])\n",
+    "].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c380eeb9-00b0-42c0-ae5e-f4f17e0115eb",
+   "metadata": {
+    "lang": "en"
+   },
+   "outputs": [],
+   "source": [
+    "# Selection of three years with isin()\n",
+    "surveys_df[\n",
+    "    surveys_df['year'].isin([1991, 1996, 2001])\n",
+    "].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4c51e4d-b68d-40a8-8cff-088e54fa34cb",
+   "metadata": {
+    "lang": "fr"
+   },
+   "outputs": [],
+   "source": [
+    "# Sélection des poids sur trois années avec .loc[]\n",
+    "surveys_df.loc[surveys_df['year'].isin([1991, 1996, 2001]), 'weight']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8aadefc-3a8b-42b9-9894-5884a05127e0",
+   "metadata": {
+    "lang": "en"
+   },
+   "outputs": [],
+   "source": [
+    "# Selection of the weights for three years with .loc[]\n",
+    "surveys_df.loc[surveys_df['year'].isin([1991, 1996, 2001]), 'weight']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e62ce6d3-edc1-4fce-9474-4abaa80b4ba9",
+   "metadata": {
+    "lang": "fr"
+   },
+   "outputs": [],
+   "source": [
+    "# Chercher des données manquantes ou erronées\n",
+    "surveys_df.loc[~surveys_df['sex'].isin(['F', 'M']), 'sex']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ef4b2e5-808d-4f9b-83e2-c47a7be6f8b1",
+   "metadata": {
+    "lang": "en"
+   },
+   "outputs": [],
+   "source": [
+    "# Search for missing or incorrect data\n",
+    "surveys_df.loc[~surveys_df['sex'].isin(['F', 'M']), 'sex']"
    ]
   },
   {
@@ -674,13 +792,7 @@
    },
    "source": [
     "### Exercices - Sélections par la présence\n",
-    "`1`. Vous pouvez utiliser la méthode `isin()` pour aller chercher\n",
-    "les enregistrements dont les valeurs d'une colonne correspondent\n",
-    "à l'une des valeurs fournies dans une liste. Par exemple :\n",
-    "```\n",
-    "surveys_df[surveys_df['nom_colonne'].isin([valeur1, valeur2, ...])]\n",
-    "```\n",
-    "Utilisez la méthode `isin()` pour trouver tous les\n",
+    "`1`. Utilisez la méthode `isin()` pour trouver tous les\n",
     "différents sites (`plot_id`) ayant certaines espèces\n",
     "(`AS`, `CQ`, `OX` et `UL`) dans le DataFrame. (4 min.)"
    ]
@@ -693,12 +805,7 @@
    },
    "source": [
     "### Exercises - Selection by presence\n",
-    "`1`. You can use the `isin()` method in python to query\n",
-    "a DataFrame based upon a list of values as follows:\n",
-    "```\n",
-    "surveys_df[surveys_df['column_name'].isin([value1, value2, ...])]\n",
-    "```\n",
-    "Use the `isin()` method to find all different\n",
+    "`1`. Use the `isin()` method to find all different\n",
     "sites (`plot_id`) that contain particular species\n",
     "(`AS`, `CQ`, `OX` and `UL`) in the surveys DataFrame. (4 min.)"
    ]
@@ -719,7 +826,7 @@
     "cond_especes = surveys_df['species_id'].isin(['AS', 'CQ', 'OX', 'UL'])\n",
     "\n",
     "# Lister les différents sites\n",
-    "surveys_df[cond_especes]['plot_id'].unique()"
+    "surveys_df.loc[cond_especes, 'plot_id'].unique()"
    ]
   },
   {
@@ -738,7 +845,7 @@
     "cond_especes = ###(['AS', 'CQ', 'OX', 'UL'])\n",
     "\n",
     "# Lister les différents sites\n",
-    "surveys_df[###][###].unique()"
+    "surveys_df.###[###].unique()"
    ]
   },
   {
@@ -757,7 +864,7 @@
     "species_mask = surveys_df['species_id'].isin(['AS', 'CQ', 'OX', 'UL'])\n",
     "\n",
     "# List all different sites\n",
-    "surveys_df[species_mask]['plot_id'].unique()"
+    "surveys_df.loc[species_mask, 'plot_id'].unique()"
    ]
   },
   {
@@ -776,7 +883,7 @@
     "species_mask = ###(['AS', 'CQ', 'OX', 'UL'])\n",
     "\n",
     "# List all different sites\n",
-    "surveys_df[###][###].unique()"
+    "surveys_df.###[###].unique()"
    ]
   },
   {
@@ -786,14 +893,13 @@
     "lang": "fr"
    },
    "source": [
-    "`2`. Créez un graphique de barres montrant la moyenne\n",
-    "des poids selon le site (`plot_id`), mais avec les résultats\n",
-    "des femelles et des mâles côte à côte pour chaque site.\n",
-    "Pour la préparation initiale des données :\n",
-    "* Créez une sélection contenant seulement les enregistrements\n",
-    "ayant une valeur de `sex` (soit `F` ou `M`) et ayant un poids supérieur à 0\n",
-    "* Pour le graphique final, vous devez limiter les données\n",
-    "aux colonnes de poids, de site et de sexe\n",
+    "`2`. Calculez la moyenne des poids\n",
+    "selon le site (`plot_id`) et le sexe :\n",
+    "* Créez une sélection contenant seulement :\n",
+    "  * Les observations ayant une valeur de sexe `F` ou `M`\n",
+    "    et ayant un poids supérieur à `0`;\n",
+    "  * Les colonnes de poids, de site et de sexe.\n",
+    "* Groupez les données et calculez les moyennes de poids.\n",
     "\n",
     "(5 min.)"
    ]
@@ -805,12 +911,12 @@
     "lang": "en"
    },
    "source": [
-    "`2`. Create a bar plot of average weight by site (`plot_id`)\n",
-    "with female and male values side by side for each site.\n",
-    "* Create a new DataFrame that contains only observations that are\n",
-    "  of sex female or male and where weight values are greater than 0\n",
-    "* For the final plot, only select the\n",
-    "  weight, the site and the sex columns\n",
+    "`2`. Get the average weight by site (`plot_id`) and sex:\n",
+    "* Create a selection that contains only:\n",
+    "  * The observations that are of sex `F` or `M`\n",
+    "    and where weight values are greater than `0`;\n",
+    "  * The weight, the site and the sex columns.\n",
+    "* Group the data and compute the average weights.\n",
     "\n",
     "(5 min.)"
    ]
@@ -832,7 +938,7 @@
     "cond_poids = surveys_df['weight'] > 0\n",
     "colonnes = ['weight', 'plot_id', 'sex']\n",
     "\n",
-    "selection = surveys_df[cond_sexe & cond_poids][colonnes]\n",
+    "selection = surveys_df.loc[cond_sexe & cond_poids, colonnes]\n",
     "selection.tail()"
    ]
   },
@@ -849,7 +955,7 @@
    "outputs": [],
    "source": [
     "# Sélection des enregistrements et des colonnes nécessaires\n",
-    "cond_sexe = surveys_df['sex']###\n",
+    "cond_sexe = surveys_df['sex'].isin(['F', 'M'])\n",
     "cond_poids = surveys_df['weight'] ###\n",
     "colonnes = ['weight', 'plot_id', 'sex']\n",
     "\n",
@@ -874,7 +980,7 @@
     "weight_mask = surveys_df['weight'] > 0\n",
     "columns = ['weight', 'plot_id', 'sex']\n",
     "\n",
-    "selection = surveys_df[sex_mask & weight_mask][columns]\n",
+    "selection = surveys_df.loc[sex_mask & weight_mask, columns]\n",
     "selection.tail()"
    ]
   },
@@ -891,7 +997,7 @@
    "outputs": [],
    "source": [
     "# Selection of the data with isin()\n",
-    "sex_mask = surveys_df['sex']###\n",
+    "sex_mask = surveys_df['sex'].isin(['F', 'M'])\n",
     "weight_mask = surveys_df['weight'] ###\n",
     "columns = ['weight', 'plot_id', 'sex']\n",
     "\n",
@@ -965,91 +1071,6 @@
     "# Calculate the mean weight for each plot_id and sex combination: \n",
     "avg_by_site_sex = selection###\n",
     "avg_by_site_sex.tail()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a2584e88-879e-4a8f-bcdc-b6bd0cba34a2",
-   "metadata": {
-    "lang": "fr"
-   },
-   "source": [
-    "`3`. L'opérateur `~` peut être utilisé pour retourner l'opposé d'une\n",
-    "sélection. C'est l'équivalent de **n'est pas**. Écrivez une requête\n",
-    "sélectionnant tous les enregistrements ne contenant ni `F`, ni `M`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7ffd5c69-247f-46e1-99b2-32a035f1554f",
-   "metadata": {
-    "lang": "en"
-   },
-   "source": [
-    "`3`. The `~` symbol in Python can be used to return the OPPOSITE\n",
-    "of the selection that you specify in python. It is equivalent\n",
-    "to **is not in**. Write a query that selects all rows\n",
-    "that are NOT equal to `F` or `M` in the surveys data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e62ce6d3-edc1-4fce-9474-4abaa80b4ba9",
-   "metadata": {
-    "lang": "fr",
-    "tags": [
-     "soln"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "surveys_df[~cond_sexe]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a4247e87-ca2a-47f1-9cb8-7a467fad8498",
-   "metadata": {
-    "lang": "fr",
-    "tags": [
-     "exer"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "surveys_df[###cond_sexe]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1ef4b2e5-808d-4f9b-83e2-c47a7be6f8b1",
-   "metadata": {
-    "lang": "en",
-    "tags": [
-     "soln"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "surveys_df[~sex_mask]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41f2fcb5-26a0-4b51-a143-61b4ed4fba63",
-   "metadata": {
-    "lang": "en",
-    "tags": [
-     "exer"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "surveys_df[###sex_mask]"
    ]
   },
   {


### PR DESCRIPTION
- Présentation officielle de `.isin()` avant l'exercice.
- Montrer que la sortie de `.isin()` peut être utilisée avec `.loc[,]`.
- Montrer l'opérateur `~` en exemple plutôt qu'en exercice; économie de temps et avant-goût du chapitre 3 pour le nettoyage.
- Révision des questions des exercices (maintenant sans graphique).
- Utilisation systématique de `.loc[]` lorsqu'il y a sélection de lignes et de colonnes.